### PR TITLE
allow passing full path other then GOPATH

### DIFF
--- a/pkg/version.mk
+++ b/pkg/version.mk
@@ -15,6 +15,10 @@ define VERSION_LDFLAGS
 $(shell $(CMD_LINKFLAGS) -pkg=$(GOPATH)/src/$(1))
 endef
 
+define VERSION_CUSTOM_FLAGS
+$(shell $(CMD_LINKFLAGS) -pkg=$(firstword $(subst :, ,$(1))))
+endef
+
 define VERSION_LDFLAGS_VENDOR
 $(addprefix -X $(strip $(1))/vendor/,$(filter-out -X,$(call VERSION_LDFLAGS,$(1))))
 endef


### PR DESCRIPTION
Allow passing a full path to gravitational pgk parameter 