### PR TITLE
fix golangci-lint.mk

### DIFF
--- a/pkg/golangci-lint.mk
+++ b/pkg/golangci-lint.mk
@@ -1,11 +1,11 @@
 export GOLANGCI_LINT:=$(GOPATH)/bin/golangci-lint
 export _SELF:=$(lastword $(MAKEFILE_LIST))
-GOLANGCI_LINT_VERSION:=v1.23.8
+GOLANGCI_LINT_VERSION:=v1.46.2
 
 # grab the golangci binary and install the actual linters
 $(GOLANGCI_LINT): | $(GOPATH)
 	$(call PROMPT,Installing $@)
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin $(GOLANGCI_LINT_VERSION)
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin $(GOLANGCI_LINT_VERSION)
 
 tools:: $(GOLANGCI_LINT)
 
@@ -15,4 +15,4 @@ clean-tools::
 update-tools:: update-golangci-lint
 
 update-golangci-lint:
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(GOPATH)/bin $(GOLANGCI_LINT_VERSION)
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin $(GOLANGCI_LINT_VERSION)


### PR DESCRIPTION
Installation instructions have changed https://golangci-lint.run/usage/install/ and the previous links resulted in empty bash script that did not do anything, resulting in a bad setup:

```
**********************************************************
*
*   (bokken.cli)    Installing /Users/mihai/go/bin/golangci-lint
*
**********************************************************

curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b /Users/mihai/go/bin v1.39.0

**********************************************************
*
*   (bokken.cli)    lint-fast
*
**********************************************************

/Users/mihai/go/bin/golangci-lint run --fast
make: /Users/mihai/go/bin/golangci-lint: No such file or directory
make: *** [lint-fast] Error 1
```

I've also updated the version to the latest recommended by golangci-lint which will introduce a new gosec false-positive on our side but hopefully will bring more fixes.