### PR TITLE
fix installing linkflags

### DIFF
--- a/pkg/version.mk
+++ b/pkg/version.mk
@@ -1,7 +1,7 @@
 CMD_LINKFLAGS:=$(GOPATH)/bin/linkflags
 $(CMD_LINKFLAGS): | $(GOPATH)
 	$(call PROMPT,Installing $@)
-	$(GO) get github.com/gravitational/version/cmd/linkflags
+	$(GO) install github.com/gravitational/version/cmd/linkflags
 
 tools:: $(CMD_LINKFLAGS)
 
@@ -9,7 +9,7 @@ clean-tools::
 	rm -f $(CMD_LINKFLAGS)
 
 update-tools::
-	$(GO) get -u github.com/gravitational/version/cmd/linkflags
+	$(GO) install -u github.com/gravitational/version/cmd/linkflags
 
 define VERSION_LDFLAGS
 $(shell $(CMD_LINKFLAGS) -pkg=$(if $(1),$(1),$(PWD)))


### PR DESCRIPTION
I was getting a lot of

```
make: /Users/mihai/go/bin/linkflags: Command not found
```

Turns out that there was a problem about the expectations of how `go get` actually works which [changed behaviour since 1.17+](https://go.dev/doc/go-get-install-deprecation) and it's not installing packages anymore. Recommendation is to use `go install` instead.